### PR TITLE
Fix shock trajectory NaNs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,23 @@ Below you can find the Bibtex citation:
 
 # Comments：
 Typically, you can directly run the xxx_PINN.ipynb file to generate the full PINN network and save it, then run the xxx_VGPT.ipynb code. If you want to use an existing xxx.pkl file to directly test the VGPT-PINN results, you need to rename the XXX_VGPT_activation.py file to XXX_GPT_activation.py and import XXX_GPT_activation in the XXXX_VGPT.ipynb file. If you have any further questions, feel free to contact me at jiyajie595@sjtu.edu.cn.
+
+## 1D explosive wave PINN
+
+A minimal physics-informed neural network example for the one-dimensional Euler equations is provided under the `pinn/` and `scripts/` directories. The configuration file `configs/default.yaml` specifies geometry, sampling, physics parameters and training hyperparameters.
+
+The M2 milestone integrates a JWL equation of state, Arrhenius reaction source term and a progress variable \(\lambda\) describing explosive burnup. The model now outputs `[rho, u, E, lambda]` and enforces energy consistency through a source term.
+
+To train the network using the default settings run
+
+```
+python scripts/train.py --config configs/default.yaml
+```
+
+After training, generate a time history at a chosen observation point and a coarse full-field snapshot grid with
+
+```
+python scripts/eval.py --config configs/default.yaml --model model.pth
+```
+
+Outputs are written to the `outputs/` directory.

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -1,0 +1,44 @@
+geometry:
+  L_tot: 1.0
+  L_charge: 0.2
+
+time:
+  T_end: 0.05
+  dt_vis: 0.0005
+
+sampling:
+  N_bc: 200
+  N_ic: 200
+  N_f: 2000
+  N_shock: 500
+
+physics:
+  gamma: 1.4
+  eos: JWL
+  jwl_params: {A: 3.712e11, B: 3.230e9, R1: 4.15, R2: 1.1, omega: 0.35}
+  use_progress_var: true
+  arrhenius_params: {A: 4.0e19, Ea: 1.0e5, Rgas: 8.314, n: 1.0, Q: 4.0e6, Cv: 1000.0}
+
+ic:
+  left: {rho: 1.0, u: 0.0, p: 1.0}
+  right: {rho: 0.125, u: 0.0, p: 0.1}
+
+loss:
+  w_pde: 1.0
+  w_ic: 1.0
+  w_bc: 1.0
+  w_shock: 0.5
+  w_rh: 0.5
+
+model:
+  mlp_hidden: [128, 128, 128, 128]
+  activation: tanh
+
+train:
+  optimizer: adam
+  lr: 0.001
+  epochs: 1000
+  save_path: model.pth
+
+evaluation:
+  x_obs: 0.5

--- a/pinn/eos_jwl.py
+++ b/pinn/eos_jwl.py
@@ -1,0 +1,26 @@
+import torch
+
+
+def jwl_pressure(rho, u, E, params):
+    """Compute pressure using a simplified JWL equation of state.
+
+    Parameters
+    ----------
+    rho : torch.Tensor
+        Density.
+    u : torch.Tensor
+        Velocity.
+    E : torch.Tensor
+        Total energy density.
+    params : dict
+        Dictionary with keys A, B, R1, R2, omega.
+    """
+    A = float(params.get("A", 1.0))
+    B = float(params.get("B", 1.0))
+    R1 = float(params.get("R1", 4.0))
+    R2 = float(params.get("R2", 1.0))
+    omega = float(params.get("omega", 0.3))
+
+    v = 1.0 / (rho + 1e-12)  # specific volume
+    e = E - 0.5 * rho * u ** 2  # internal energy density
+    return A * torch.exp(-R1 * v) + B * torch.exp(-R2 * v) + omega * e / v

--- a/pinn/evaluate.py
+++ b/pinn/evaluate.py
@@ -1,0 +1,72 @@
+import os
+import torch
+import numpy as np
+import matplotlib.pyplot as plt
+
+from .eos_jwl import jwl_pressure
+from .indicators import shock_indicator
+
+
+def evaluate(model, cfg, device=None, out_dir="outputs"):
+    device = device or ("cuda" if torch.cuda.is_available() else "cpu")
+    model.to(device)
+    model.eval()
+
+    L = cfg["geometry"]["L_tot"]
+    T = cfg["time"]["T_end"]
+    dt = cfg["time"]["dt_vis"]
+    x_obs = cfg.get("evaluation", {}).get("x_obs", L / 2)
+
+    xs = torch.linspace(0, L, 1000)
+    ts = torch.arange(0, T + 1e-12, dt)
+    X, Tm = torch.meshgrid(xs, ts, indexing="ij")
+    xt = torch.stack([X.reshape(-1), Tm.reshape(-1)], dim=1).to(device)
+
+    xt = xt.requires_grad_(True)
+    pred = model(xt)
+    ind = shock_indicator(model, xt)
+    rho, u, E, lam = [pred[:, i:i+1] for i in range(4)]
+    p = jwl_pressure(rho, u, E, cfg["physics"].get("jwl_params", {}))
+
+    nx, nt = X.shape
+    rho = rho.detach().cpu().numpy().reshape(nx, nt)
+    u = u.detach().cpu().numpy().reshape(nx, nt)
+    p = p.detach().cpu().numpy().reshape(nx, nt)
+    # Clamp NaN/Inf values in the indicator to avoid argmax returning index 0
+    ind = torch.nan_to_num(ind.detach(), nan=0.0, posinf=0.0, neginf=0.0).view(nx, nt)
+
+    os.makedirs(out_dir, exist_ok=True)
+    # Time history at observation point
+    x_obs_t = torch.full((len(ts), 1), x_obs)
+    xt_obs = torch.cat([x_obs_t, ts.unsqueeze(1)], dim=1).to(device)
+    with torch.no_grad():
+        pred_obs = model(xt_obs)
+    rho_o, u_o, E_o, lam_o = [pred_obs[:, i:i+1] for i in range(4)]
+    p_o = jwl_pressure(rho_o, u_o, E_o, cfg["physics"].get("jwl_params", {}))
+    data = torch.cat([ts.unsqueeze(1), rho_o, u_o, p_o], dim=1).cpu().numpy()
+    np.savetxt(os.path.join(out_dir, "time_history.csv"), data, delimiter=",", header="t,rho,u,p", comments="")
+
+    # Simple visualization of pressure field
+    plt.figure()
+    plt.pcolormesh(ts.cpu().numpy(), xs.cpu().numpy(), p, shading="auto")
+    plt.xlabel("t")
+    plt.ylabel("x")
+    plt.colorbar(label="p")
+    plt.tight_layout()
+    plt.savefig(os.path.join(out_dir, "pressure_field.png"))
+    plt.close()
+
+    # Shock trajectory
+    val, idx = ind.max(dim=0)
+    shock_x = torch.where(val > 0, xs[idx], torch.full_like(val, float("nan")))
+    traj = torch.stack([ts, shock_x], dim=1).cpu().numpy()
+    np.savetxt(os.path.join(out_dir, "shock_traj.csv"), traj, delimiter=",", header="t,x_shock", comments="")
+    plt.figure()
+    plt.plot(ts.cpu().numpy(), shock_x.cpu().numpy())
+    plt.xlabel("t")
+    plt.ylabel("shock position")
+    plt.tight_layout()
+    plt.savefig(os.path.join(out_dir, "shock_traj.png"))
+    plt.close()
+
+    return {"rho": rho, "u": u, "p": p}

--- a/pinn/indicators.py
+++ b/pinn/indicators.py
@@ -1,0 +1,12 @@
+import torch
+import torch.autograd as autograd
+
+def shock_indicator(model, xt):
+    """Gradient-based shock indicator using density gradient magnitude."""
+    # Ensure xt is a leaf tensor with grad enabled to avoid zeros from autograd
+    xt = xt.clone().detach().requires_grad_(True)
+    rho = model(xt)[:, 0:1]
+    grad_rho = autograd.grad(rho, xt, torch.ones_like(rho), create_graph=False)[0]
+    ind = grad_rho[:, 0:1].abs()
+    # Replace any NaN/Inf values that can arise from ill-conditioned gradients
+    return torch.nan_to_num(ind, nan=0.0, posinf=0.0, neginf=0.0)

--- a/pinn/losses.py
+++ b/pinn/losses.py
@@ -1,0 +1,93 @@
+import torch
+import torch.autograd as autograd
+import torch.nn.functional as F
+
+from .eos_jwl import jwl_pressure
+from .source_terms import arrhenius_rate, energy_source
+from .indicators import shock_indicator
+
+
+def euler_residual(model, xt, cfg):
+    """Compute residuals of 1D Euler equations with JWL EOS and source terms."""
+    xt = xt.requires_grad_(True)
+    pred = model(xt)
+    rho, u, E, lam = pred[:, 0:1], pred[:, 1:2], pred[:, 2:3], pred[:, 3:4]
+
+    p = jwl_pressure(rho, u, E, cfg["physics"].get("jwl_params", {}))
+
+    grad_rho = autograd.grad(rho, xt, torch.ones_like(rho), create_graph=True)[0]
+    rho_x, rho_t = grad_rho[:, 0:1], grad_rho[:, 1:2]
+
+    rho_u = rho * u
+    grad_rho_u = autograd.grad(rho_u, xt, torch.ones_like(rho_u), create_graph=True)[0]
+    rho_u_x, rho_u_t = grad_rho_u[:, 0:1], grad_rho_u[:, 1:2]
+
+    momentum_flux = rho * u ** 2 + p
+    grad_mom_flux = autograd.grad(momentum_flux, xt, torch.ones_like(momentum_flux), create_graph=True)[0]
+    mom_flux_x = grad_mom_flux[:, 0:1]
+
+    grad_E = autograd.grad(E, xt, torch.ones_like(E), create_graph=True)[0]
+    E_x, E_t = grad_E[:, 0:1], grad_E[:, 1:2]
+
+    energy_flux = u * (E + p)
+    grad_energy_flux = autograd.grad(energy_flux, xt, torch.ones_like(energy_flux), create_graph=True)[0]
+    energy_flux_x = grad_energy_flux[:, 0:1]
+
+    grad_lam = autograd.grad(lam, xt, torch.ones_like(lam), create_graph=True)[0]
+    lam_t = grad_lam[:, 1:2]
+    rate = arrhenius_rate(rho, u, E, lam, xt, cfg)
+    S = energy_source(rho, u, E, lam, xt, cfg)
+
+    mass_res = rho_t + rho_u_x
+    mom_res = rho_u_t + mom_flux_x
+    energy_res = E_t + energy_flux_x - S
+    lambda_res = lam_t - rate
+    return mass_res, mom_res, energy_res, lambda_res
+
+
+def pde_loss(model, xt, cfg):
+    mass, mom, energy, lam = euler_residual(model, xt, cfg)
+    return (mass ** 2).mean() + (mom ** 2).mean() + (energy ** 2).mean() + (lam ** 2).mean()
+
+
+def shock_loss(model, xt, cfg):
+    mass, mom, energy, lam = euler_residual(model, xt, cfg)
+    weight = shock_indicator(model, xt)
+    weight = weight / (weight.max() + 1e-8)
+    res = mass ** 2 + mom ** 2 + energy ** 2 + lam ** 2
+    return (weight * res).mean()
+
+
+def rh_loss(model, xt, cfg, eps=1e-3):
+    L = cfg["geometry"]["L_tot"]
+    xt_l = xt.clone()
+    xt_r = xt.clone()
+    xt_l[:, 0] = torch.clamp(xt_l[:, 0] - eps, 0.0, L)
+    xt_r[:, 0] = torch.clamp(xt_r[:, 0] + eps, 0.0, L)
+    pred_l = model(xt_l)
+    pred_r = model(xt_r)
+    rho_l, u_l, E_l = pred_l[:, 0:1], pred_l[:, 1:2], pred_l[:, 2:3]
+    rho_r, u_r, E_r = pred_r[:, 0:1], pred_r[:, 1:2], pred_r[:, 2:3]
+    p_l = jwl_pressure(rho_l, u_l, E_l, cfg["physics"].get("jwl_params", {}))
+    p_r = jwl_pressure(rho_r, u_r, E_r, cfg["physics"].get("jwl_params", {}))
+    mass_flux_l = rho_l * u_l
+    mass_flux_r = rho_r * u_r
+    mom_flux_l = rho_l * u_l ** 2 + p_l
+    mom_flux_r = rho_r * u_r ** 2 + p_r
+    energy_flux_l = u_l * (E_l + p_l)
+    energy_flux_r = u_r * (E_r + p_r)
+    return (
+        (mass_flux_l - mass_flux_r) ** 2
+        + (mom_flux_l - mom_flux_r) ** 2
+        + (energy_flux_l - energy_flux_r) ** 2
+    ).mean()
+
+
+def ic_loss(model, xt, true_u):
+    pred = model(xt)
+    return F.mse_loss(pred, true_u)
+
+
+def bc_loss(model, xt, true_u):
+    pred = model(xt)
+    return F.mse_loss(pred, true_u)

--- a/pinn/networks.py
+++ b/pinn/networks.py
@@ -1,0 +1,49 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+class Sine(nn.Module):
+    def forward(self, x):
+        return torch.sin(x)
+
+ACTIVATIONS = {
+    "tanh": nn.Tanh,
+    "relu": nn.ReLU,
+    "swish": nn.SiLU,
+    "sine": Sine,
+}
+class MLP(nn.Module):
+    """Simple fully-connected network mapping (x,t) -> flow variables."""
+
+    def __init__(self, in_dim: int = 2, out_dim: int = 4, hidden_layers=None, activation: str = "tanh"):
+        """
+        Parameters
+        ----------
+        in_dim : int
+            Dimension of input coordinates (default 2 for x,t).
+        out_dim : int
+            Dimension of output state. M2 uses [rho, u, E, lambda].
+        hidden_layers : list[int]
+            Sizes of hidden layers.
+        activation : str
+            Activation name from ``ACTIVATIONS``.
+        """
+        super().__init__()
+        hidden_layers = hidden_layers or [128, 128, 128]
+        act_cls = ACTIVATIONS.get(activation, nn.Tanh)
+        layers = []
+        last_dim = in_dim
+        for h in hidden_layers:
+            layers.append(nn.Linear(last_dim, h))
+            layers.append(act_cls())
+            last_dim = h
+        layers.append(nn.Linear(last_dim, out_dim))
+        self.model = nn.Sequential(*layers)
+
+    def forward(self, x):
+        raw = self.model(x)
+        raw_rho, u, raw_E, raw_lam = raw[:, 0:1], raw[:, 1:2], raw[:, 2:3], raw[:, 3:4]
+        rho = F.softplus(raw_rho)
+        E = F.softplus(raw_E)
+        lam = torch.sigmoid(raw_lam)
+        return torch.cat([rho, u, E, lam], dim=1)

--- a/pinn/sampling.py
+++ b/pinn/sampling.py
@@ -1,0 +1,84 @@
+import torch
+from .indicators import shock_indicator
+
+
+def sample_initial(cfg):
+    N = cfg["sampling"]["N_ic"]
+    L = cfg["geometry"]["L_tot"]
+    Lc = cfg["geometry"]["L_charge"]
+    gamma = cfg["physics"].get("gamma", 1.4)
+    left = cfg["ic"]["left"]
+    right = cfg["ic"]["right"]
+    x = torch.rand(N, 1) * L
+    t = torch.zeros_like(x)
+    rho = torch.where(x <= Lc, torch.full_like(x, left["rho"]), torch.full_like(x, right["rho"]))
+    u = torch.where(x <= Lc, torch.full_like(x, left["u"]), torch.full_like(x, right["u"]))
+    p = torch.where(x <= Lc, torch.full_like(x, left["p"]), torch.full_like(x, right["p"]))
+    E = p / (gamma - 1.0) + 0.5 * rho * u ** 2
+    lam = torch.where(x <= Lc, torch.zeros_like(x), torch.ones_like(x))
+    xt = torch.cat([x, t], dim=1)
+    u_vec = torch.cat([rho, u, E, lam], dim=1)
+    return xt, u_vec
+
+
+def sample_boundary(cfg):
+    N = cfg["sampling"]["N_bc"]
+    L = cfg["geometry"]["L_tot"]
+    Lc = cfg["geometry"]["L_charge"]
+    T = cfg["time"]["T_end"]
+    gamma = cfg["physics"].get("gamma", 1.4)
+    left = cfg["ic"]["left"]
+    right = cfg["ic"]["right"]
+    t = torch.rand(N, 1) * T
+
+    x0 = torch.zeros_like(t)
+    xt_left = torch.cat([x0, t], dim=1)
+    E_left = left["p"] / (gamma - 1.0) + 0.5 * left["rho"] * left["u"] ** 2
+    u_left = torch.tensor([left["rho"], left["u"], E_left, 0.0]).repeat(N, 1)
+
+    xL = torch.full_like(t, L)
+    xt_right = torch.cat([xL, t], dim=1)
+    E_right = right["p"] / (gamma - 1.0) + 0.5 * right["rho"] * right["u"] ** 2
+    lam_right = 1.0 if L > Lc else 0.0
+    u_right = torch.tensor([right["rho"], right["u"], E_right, lam_right]).repeat(N, 1)
+    return (xt_left, u_left), (xt_right, u_right)
+
+
+def sample_residual(cfg):
+    N = cfg["sampling"]["N_f"]
+    L = cfg["geometry"]["L_tot"]
+    T = cfg["time"]["T_end"]
+    x = torch.rand(N, 1) * L
+    t = torch.rand(N, 1) * T
+    return torch.cat([x, t], dim=1)
+
+
+def resample_shock_points(model, cfg):
+    N = cfg["sampling"].get("N_shock", 0)
+    if N <= 0:
+        return None
+    device = next(model.parameters()).device
+    L = cfg["geometry"]["L_tot"]
+    T = cfg["time"]["T_end"]
+    N_candidates = N * 5
+    x = torch.rand(N_candidates, 1, device=device) * L
+    t = torch.rand(N_candidates, 1, device=device) * T
+    xt = torch.cat([x, t], dim=1)
+    ind = shock_indicator(model, xt).detach().squeeze()
+    topk = torch.topk(ind, k=N, largest=True).indices
+    return xt[topk].detach()
+
+
+def sample_training_points(cfg):
+    ic_xt, ic_u = sample_initial(cfg)
+    (bc_left_xt, bc_left_u), (bc_right_xt, bc_right_u) = sample_boundary(cfg)
+    f_xt = sample_residual(cfg)
+    return {
+        "ic_xt": ic_xt,
+        "ic_u": ic_u,
+        "bc_left_xt": bc_left_xt,
+        "bc_left_u": bc_left_u,
+        "bc_right_xt": bc_right_xt,
+        "bc_right_u": bc_right_u,
+        "f_xt": f_xt,
+    }

--- a/pinn/source_terms.py
+++ b/pinn/source_terms.py
@@ -1,0 +1,25 @@
+import torch
+
+def arrhenius_rate(rho, u, E, lam, xt, cfg):
+    """Arrhenius-type reaction rate limited to explosive region."""
+    params = cfg["physics"].get("arrhenius_params", {})
+    A = float(params.get("A", 0.0))
+    Ea = float(params.get("Ea", 0.0))
+    Rgas = float(params.get("Rgas", 8.314))
+    n = float(params.get("n", 1.0))
+    Cv = float(params.get("Cv", 1000.0))
+    Lc = cfg["geometry"]["L_charge"]
+    x = xt[:, 0:1]
+    # Specific internal energy and temperature approximation
+    e = E - 0.5 * rho * u ** 2
+    T = e / (rho * Cv + 1e-12)
+    T = torch.clamp(T, min=1.0)
+    exp_arg = torch.clamp(-Ea / (Rgas * (T + 1e-12)), max=50.0)
+    rate = A * torch.exp(exp_arg) * (1 - lam.clamp(min=0.0, max=1.0)) ** n
+    chi = (x <= Lc).float()
+    return rate * chi
+
+def energy_source(rho, u, E, lam, xt, cfg):
+    rate = arrhenius_rate(rho, u, E, lam, xt, cfg)
+    Q = float(cfg["physics"]["arrhenius_params"].get("Q", 0.0))
+    return rho * Q * rate

--- a/pinn/trainer.py
+++ b/pinn/trainer.py
@@ -1,0 +1,46 @@
+import torch
+from .networks import MLP
+from .losses import pde_loss, ic_loss, bc_loss, shock_loss, rh_loss
+from . import sampling
+
+
+def train(cfg, device=None):
+    device = device or ("cuda" if torch.cuda.is_available() else "cpu")
+    model = MLP(out_dim=4, hidden_layers=cfg["model"]["mlp_hidden"], activation=cfg["model"]["activation"]).to(device)
+
+    data = sampling.sample_training_points(cfg)
+    for k in data:
+        data[k] = data[k].to(device)
+
+    opt = torch.optim.Adam(model.parameters(), lr=cfg["train"]["lr"])
+    epochs = cfg["train"]["epochs"]
+
+    for ep in range(epochs):
+        opt.zero_grad()
+        loss_pde = pde_loss(model, data["f_xt"], cfg)
+        loss_ic = ic_loss(model, data["ic_xt"], data["ic_u"])
+        bc_left = bc_loss(model, data["bc_left_xt"], data["bc_left_u"])
+        bc_right = bc_loss(model, data["bc_right_xt"], data["bc_right_u"])
+        loss_bc = bc_left + bc_right
+        shock_xt = sampling.resample_shock_points(model, cfg)
+        if shock_xt is not None:
+            loss_shock = shock_loss(model, shock_xt, cfg)
+            loss_rh = rh_loss(model, shock_xt, cfg)
+        else:
+            loss_shock = torch.tensor(0.0, device=device)
+            loss_rh = torch.tensor(0.0, device=device)
+        loss = (
+            cfg["loss"]["w_pde"] * loss_pde
+            + cfg["loss"]["w_ic"] * loss_ic
+            + cfg["loss"]["w_bc"] * loss_bc
+            + cfg["loss"].get("w_shock", 0.0) * loss_shock
+            + cfg["loss"].get("w_rh", 0.0) * loss_rh
+        )
+        loss.backward()
+        opt.step()
+        if (ep + 1) % 100 == 0:
+            print(f"Epoch {ep+1}/{epochs}: loss={loss.item():.4e}")
+    save_path = cfg["train"].get("save_path")
+    if save_path:
+        torch.save(model.state_dict(), save_path)
+    return model

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+torch
+pyyaml
+numpy
+matplotlib

--- a/scripts/eval.py
+++ b/scripts/eval.py
@@ -1,0 +1,26 @@
+import argparse
+import os
+import sys
+import yaml
+import torch
+
+# Ensure repository root is on sys.path
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from pinn import networks, evaluate
+
+
+def main(cfg_path, model_path):
+    with open(cfg_path, "r") as f:
+        cfg = yaml.safe_load(f)
+    model = networks.MLP(out_dim=4, hidden_layers=cfg["model"]["mlp_hidden"], activation=cfg["model"]["activation"])
+    state = torch.load(model_path, map_location="cpu")
+    model.load_state_dict(state)
+    evaluate.evaluate(model, cfg)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Evaluate 1D Euler PINN")
+    parser.add_argument("--config", default="configs/default.yaml")
+    parser.add_argument("--model", default="model.pth")
+    args = parser.parse_args()
+    main(args.config, args.model)

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -1,0 +1,21 @@
+import argparse
+import os
+import sys
+import yaml
+
+# Ensure repository root is on sys.path
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from pinn import trainer
+
+
+def main(cfg_path):
+    with open(cfg_path, "r") as f:
+        cfg = yaml.safe_load(f)
+    trainer.train(cfg)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Train 1D Euler PINN")
+    parser.add_argument("--config", default="configs/default.yaml")
+    args = parser.parse_args()
+    main(args.config)


### PR DESCRIPTION
## Summary
- Stabilize shock indicator by detaching inputs and clamping NaN/Inf gradients
- Guard shock tracking in evaluation to ignore non-finite indicators and return NaN when no shock is detected

## Testing
- `pip install torch` *(succeeds)*
- `pip install pyyaml numpy matplotlib`
- `python scripts/train.py --config configs/default.yaml` *(fails: KeyboardInterrupt during backprop)*
- `python scripts/eval.py --config configs/default.yaml --model model.pth` *(fails: FileNotFoundError: model.pth)*

------
https://chatgpt.com/codex/tasks/task_e_689a06835880832092adeb2feef26f16